### PR TITLE
Add explanatory info for correlation cards and options

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -106,6 +106,12 @@
       font-weight: 600;
     }
 
+    .card .info {
+      font-size: 0.875em;
+      color: #555;
+      margin-top: 0.5em;
+    }
+
     .corr-low .value {
       color: #2e7d32;
     }
@@ -330,9 +336,28 @@
       const avgMerit = meritData.length
         ? meritData.reduce((a, r) => a + parseFloat(r.Korrelation || 0), 0) / meritData.length
         : 0;
-      if (!cardOgiltig) cardOgiltig = addCard("Medel korrelation – Ogiltig", "N/A");
-      if (!cardTotal) cardTotal = addCard("Medel korrelation – Total", "N/A");
-      if (!cardMerit) cardMerit = addCard("Medel korrelation – Meritvärde", "N/A");
+      const infoText = "Korrelationen visar styrkan i sambandet. Värden nära 1 eller −1 betyder starkt samband.";
+      if (!cardOgiltig)
+        cardOgiltig = addCard(
+          "Medel korrelation – Ogiltig",
+          "N/A",
+          "",
+          infoText
+        );
+      if (!cardTotal)
+        cardTotal = addCard(
+          "Medel korrelation – Total",
+          "N/A",
+          "",
+          infoText
+        );
+      if (!cardMerit)
+        cardMerit = addCard(
+          "Medel korrelation – Meritvärde",
+          "N/A",
+          "",
+          infoText
+        );
       cardOgiltig.querySelector(".value").textContent = ogiltigData.length ? avgOgiltig.toFixed(2) : "N/A";
       cardOgiltig.className = `card ${getCorrClass(avgOgiltig)}`;
       cardTotal.querySelector(".value").textContent = totalData.length ? avgTotal.toFixed(2) : "N/A";
@@ -364,10 +389,12 @@
       });
     }
 
-    function addCard(title, value, klass = "") {
+    function addCard(title, value, klass = "", info = "") {
       const card = document.createElement("div");
       card.className = `card ${klass}`;
-      card.innerHTML = `<h3>${title}</h3><div class="value">${value}</div>`;
+      card.innerHTML = `<h3>${title}</h3><div class="value">${value}</div>${
+        info ? `<div class="info">${info}</div>` : ""
+      }`;
       document.getElementById("dashboard").appendChild(card);
       return card;
     }

--- a/docs/landing.html
+++ b/docs/landing.html
@@ -58,11 +58,19 @@
     }
     .option {
       display: flex;
-      align-items: center;
+      align-items: flex-start;
       margin-bottom: 0.75rem;
     }
     .option input {
       margin-right: 0.5rem;
+    }
+    .option .text {
+      display: flex;
+      flex-direction: column;
+    }
+    .option .info {
+      font-size: 0.8rem;
+      color: #555;
     }
     main {
       flex: 1;
@@ -116,16 +124,32 @@
       <h2>Välj korrelationer</h2>
       <form id="correlationForm">
         <label class="option">
-          <input type="checkbox" value="ogiltig"> Ogiltig frånvaro
+          <input type="checkbox" value="ogiltig">
+          <div class="text">
+            Ogiltig frånvaro
+            <div class="info">Frånvaro utan giltig orsak.</div>
+          </div>
         </label>
         <label class="option">
-          <input type="checkbox" value="total"> Total frånvaro
+          <input type="checkbox" value="total">
+          <div class="text">
+            Total frånvaro
+            <div class="info">Inkluderar både giltig och ogiltig frånvaro.</div>
+          </div>
         </label>
         <label class="option">
-          <input type="checkbox" value="merit"> Meritvärde
+          <input type="checkbox" value="merit">
+          <div class="text">
+            Meritvärde
+            <div class="info">Summan av elevens betygspoäng.</div>
+          </div>
         </label>
         <label class="option">
-          <input type="checkbox" value="amnesvis"> Ämnesvis korrelation
+          <input type="checkbox" value="amnesvis">
+          <div class="text">
+            Ämnesvis korrelation
+            <div class="info">Samband mellan frånvaro och betyg i varje ämne.</div>
+          </div>
         </label>
         <button type="submit">Se korrelationer</button>
       </form>


### PR DESCRIPTION
## Summary
- Add help text under each correlation card explaining what the correlation values represent.
- Extend landing page options with short descriptions for each checkbox.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689216b3add8832896b79c6401d4a979